### PR TITLE
Aula 02 do curso "Symfony Framework: formulários, validação e sessão"

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -3,6 +3,7 @@ framework:
     secret: '%env(APP_SECRET)%'
     #csrf_protection: true
     handle_all_throwables: true
+    http_method_override: true
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.

--- a/src/Controller/SeriesController.php
+++ b/src/Controller/SeriesController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\SeriesEntity;
 use App\Repository\SeriesRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,10 +13,7 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class SeriesController extends AbstractController
 {
-    public function __construct(private SeriesRepository $seriesRepository)
-    {
-
-    }
+    public function __construct(private SeriesRepository $seriesRepository) { }
 
     #[Route('/series', 'app_series', methods: ['GET'])]
     public function getAll(): Response
@@ -40,6 +38,19 @@ class SeriesController extends AbstractController
         $series = new SeriesEntity($seriesName);
 
         $this->seriesRepository->add($series, true);
+
+        return new RedirectResponse('/series');
+    }
+
+    #[Route(
+        '/series/delete/{id}',
+        'app_delete_series',
+        ['id' => '\d+'],
+        methods: ['DELETE']
+    )]
+    public function deleteSeries(int $id): RedirectResponse
+    {
+        $this->seriesRepository->removeById($id);
 
         return new RedirectResponse('/series');
     }

--- a/src/Repository/SeriesRepository.php
+++ b/src/Repository/SeriesRepository.php
@@ -30,4 +30,11 @@ class SeriesRepository extends ServiceEntityRepository
             $this->getEntityManager()->flush();
         } 
     }
+
+    public function removeById(int $id, bool $flush = true): void
+    {
+        $series = $this->getEntityManager()
+            ->getPartialReference(SeriesEntity::class, $id);
+        $this->remove($series, $flush);
+    }
 }

--- a/templates/series/index.html.twig
+++ b/templates/series/index.html.twig
@@ -10,7 +10,17 @@
 
     <ul class="list-group">
         {% for series in seriesList %}
-            <li class="list-group-item">{{ series.getName() }}</li>
+            <li class="list-group-item d-flex justify-content-between">
+                {{ series.getName() }}
+
+                <form
+                    method="post"
+                    action="{{ path('app_delete_series', { id: series.id }) }}"
+                >
+                    <input type="hidden" name="_method" value="DELETE">
+                    <button href="#" class="btn btn-sm btn-danger">X</button>
+                </form>
+            </li>
         {% endfor %}
     </ul>
 </div>


### PR DESCRIPTION
### Nessa aula, nós aprendemos:

- O motivo de não se ter um link para realizar ações destrutivas como remover uma série, por exemplo. Ao invés disso nós criamos um formulário que só contém um botão;
- Mais sobre como o Symfony trabalha a injeção de dependências de forma praticamente mágica. Basta pedir algum parâmetro que o Symfony vai se esforçar para nos entregá-lo;
- A definir rotas com parâmetros obrigatórios, ou seja, agora nós conseguimos obter dados de nossas rotas sem precisar usar query strings, por exemplo. Com isso nós podemos definir rotas mais “certeiras”.